### PR TITLE
fixed entities using level random rather than entity random

### DIFF
--- a/src/main/java/ttv/migami/jeg/entity/monster/Ghoul.java
+++ b/src/main/java/ttv/migami/jeg/entity/monster/Ghoul.java
@@ -56,7 +56,7 @@ public class Ghoul extends Zombie {
     @Override
     public void aiStep() {
         if (this.isAlive() && this.level() instanceof ServerLevel serverLevel) {
-            if (serverLevel.random.nextFloat() <= 0.2F) {
+            if (this.random.nextFloat() <= 0.2F) {
                 serverLevel.sendParticles(
                         ParticleTypes.SOUL,
                         this.getX(),

--- a/src/main/java/ttv/migami/jeg/entity/monster/phantom/TerrorPhantom.java
+++ b/src/main/java/ttv/migami/jeg/entity/monster/phantom/TerrorPhantom.java
@@ -269,7 +269,7 @@ public class TerrorPhantom extends AbstractTerrorPhantom {
                 (24 + random.nextInt(24)) * (random.nextBoolean() ? -1 : 1)
             );
 
-            int count = 1 + serverLevel.random.nextInt(1);
+            int count = 1 + this.random.nextInt(1);
             for (int i = 0; i < count; i++) {
                 PhantomGunner phantom = new PhantomGunnerMinion(ModEntities.PHANTOM_GUNNER_MINION.get(), serverLevel);
                 Vec3 pos = Vec3.atCenterOf(spawnPos).add(random.nextGaussian() * 2, 2, random.nextGaussian() * 2);

--- a/src/main/java/ttv/migami/jeg/entity/monster/phantom/TerrorPhantomGuardian.java
+++ b/src/main/java/ttv/migami/jeg/entity/monster/phantom/TerrorPhantomGuardian.java
@@ -169,7 +169,7 @@ public class TerrorPhantomGuardian extends TerrorPhantom {
                     0.6D,
                     0.01D
                 );
-                serverLevel.playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.GENERIC_EXPLODE, SoundSource.HOSTILE, 3.0F, 0.8F + serverLevel.random.nextFloat() * 0.2F);
+                serverLevel.playSound(null, this.getX(), this.getY(), this.getZ(), SoundEvents.GENERIC_EXPLODE, SoundSource.HOSTILE, 3.0F, 0.8F + this.random.nextFloat() * 0.2F);
                 serverLevel.explode(this, this.getX(), this.getY(), this.getZ(), 1.0F, Level.ExplosionInteraction.NONE);
             }
         }

--- a/src/main/java/ttv/migami/jeg/event/GunEvents.java
+++ b/src/main/java/ttv/migami/jeg/event/GunEvents.java
@@ -161,13 +161,17 @@ public final class GunEvents {
         }
 
         double conversionChance = Config.pillagerGunnerChance();
-        if (conversionChance <= 0.0D || serverLevel.random.nextDouble() >= conversionChance) {
+
+        // Replaced serverLevel.random with pillager.getRandom()
+        if (conversionChance <= 0.0D || pillager.getRandom().nextDouble() >= conversionChance) {
             return;
         }
 
         // Since GunnerEntity was removed, we just tag the pillager instead
         pillager.addTag("jeg_pillager_gunner");
-        ResourceLocation selected = selectRandomGun(serverLevel.random);
+
+        // Replaced serverLevel.random with pillager.getRandom()
+        ResourceLocation selected = selectRandomGun(pillager.getRandom());
         if (selected != null) {
             equipPillagerWithGun(pillager, selected);
         }
@@ -199,7 +203,7 @@ public final class GunEvents {
 
         if (event.getSpawnType() == net.minecraft.world.entity.MobSpawnType.NATURAL) {
             double terrorChance = Config.terrorPhantomChance();
-            if (terrorChance > 0.0D && serverLevel.random.nextDouble() < terrorChance) {
+            if (terrorChance > 0.0D && phantom.getRandom().nextDouble() < terrorChance) {
                 TerrorPhantom terror = new TerrorPhantom(ModEntities.TERROR_PHANTOM.get(), serverLevel);
                 if (terror != null) {
                     terror.setPos(phantom.getX(), phantom.getY(), phantom.getZ());
@@ -214,7 +218,7 @@ public final class GunEvents {
             }
 
             double gunnerChance = Config.phantomGunnerChance();
-            if (gunnerChance <= 0.0D || serverLevel.random.nextDouble() >= gunnerChance) {
+            if (gunnerChance <= 0.0D || phantom.getRandom().nextDouble() >= gunnerChance) {
                 return;
             }
         } else {


### PR DESCRIPTION
The fix prevents a crash when using C2ME given by non-thread-local (level random) rng is accessed. I only fixed it for neoforge 1.21.1 though because I'm lazy